### PR TITLE
Use ghcr.io/riscv/riscv-docs-base-container-image:latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DOCS := \
 DATE ?= $(shell date +%Y-%m-%d)
 VERSION ?= v0.0.0
 REVMARK ?= Draft
-DOCKER_IMG := docker.io/riscvintl/riscv-docs-base-container-image:latest
+DOCKER_IMG := ghcr.io/riscv/riscv-docs-base-container-image:latest
 DOCKER_BIN ?= docker
 ifneq ($(SKIP_DOCKER),true)
 	DOCKER_IS_PODMAN = \


### PR DESCRIPTION
This updates the docs container image reference in the root Makefile.

The old `riscvintl` image has been replaced with the `ghcr.io/riscv` image.
